### PR TITLE
add type to AddCommandOptions callback

### DIFF
--- a/src/types/native.ts
+++ b/src/types/native.ts
@@ -440,7 +440,7 @@ type PanelConfig = {
 
 export type AddCommandOptions = {
   label: string;
-  callback: () => void;
+  callback: (() => void) | ((uids: string[]) => Promise<void>);
   disableHotkey?: boolean;
   defaultHotkey?: string | string[];
 };


### PR DESCRIPTION
I must have had callback on AddCommandOptions on `callback: any;` in my node_modules for https://github.com/dvargas92495/roamjs-components/commit/08714fe4abfecf449376b2e0cceb3fc79bc83bd6

Because now I'm getting a bunch of type errors.

This commit takes care of all of them but
```
features\workBench.ts(563,7)
      TS2322: Type '(uids: string[]) => Promise<(string | void)[]>' is not assignable to type '(() => void) | ((uids: string[]) => Promise<void>)'.
  Type '(uids: string[]) => Promise<(string | void)[]>' is not assignable to type '() => void'.
```

I can't seem to deal with that one.

@dvargas92495 