### PR TITLE
Allow JSX descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.87.0",
+      "version": "0.88.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/components/ConfigPanels/types.ts
+++ b/src/components/ConfigPanels/types.ts
@@ -106,6 +106,6 @@ export type UnionField =
 
 export type Field<T extends UnionField> = Omit<T, "type"> & {
   title: string;
-  description: string;
+  description: React.ReactNode;
   Panel: FieldPanel<T>;
 };

--- a/src/components/Description.tsx
+++ b/src/components/Description.tsx
@@ -4,7 +4,7 @@ import React from "react";
 const Description = ({
   description,
 }: {
-  description: string;
+  description: React.ReactNode;
 }): React.ReactElement => {
   return (
     <span


### PR DESCRIPTION
## Summary
- widen Description's description prop to React.ReactNode
- allow config panel field descriptions to accept React nodes for links and other JSX content

## Test
- npm run build