### PR TITLE
Add tooltip interactionKind support to Description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.88.0",
+  "version": "0.88.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.88.0",
+      "version": "0.88.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.88.0",
+  "version": "0.88.1",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/components/Description.tsx
+++ b/src/components/Description.tsx
@@ -1,11 +1,19 @@
-import { Tooltip, Icon } from "@blueprintjs/core";
+import { Tooltip, Icon, PopoverInteractionKind } from "@blueprintjs/core";
 import React from "react";
+
+type TooltipInteractionKind = React.ComponentProps<
+  typeof Tooltip
+>["interactionKind"];
+
+type DescriptionProps = {
+  description: React.ReactNode;
+  interactionKind?: TooltipInteractionKind;
+};
 
 const Description = ({
   description,
-}: {
-  description: React.ReactNode;
-}): React.ReactElement => {
+  interactionKind = PopoverInteractionKind.HOVER_TARGET_ONLY,
+}: DescriptionProps): React.ReactElement => {
   return (
     <span
       style={{
@@ -16,6 +24,7 @@ const Description = ({
       }}
     >
       <Tooltip
+        interactionKind={interactionKind}
         content={
           <span style={{ maxWidth: 400, display: "inline-block" }}>
             {description}


### PR DESCRIPTION
## Summary
- Allow `Description` to accept `interactionKind` and forward it to Blueprint `Tooltip`
- Default `interactionKind` to `PopoverInteractionKind.HOVER_TARGET_ONLY`, matching Blueprint's tooltip default
- Broaden config panel field descriptions to `React.ReactNode` so JSX descriptions are supported end to end

## Testing
- `npm run build` passed