### PR TITLE
[codex] Add semantic search Roam API types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.88.1",
+      "version": "0.88.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/testing/mockRoamEnvironment.ts
+++ b/src/testing/mockRoamEnvironment.ts
@@ -1480,9 +1480,18 @@ const mockRoamEnvironment = () => {
   };
   global.window.roamAlphaAPI.data = {
     ...global.window.roamAlphaAPI.data,
+    semanticSearchEnabled: () => false,
     fast: {
       q: (query, ..._params) => {
         return mockQuery({ graph, query });
+      },
+    },
+    async: {
+      ...global.window.roamAlphaAPI.data?.async,
+      semanticSearch: async () => {
+        throw new Error(
+          "Semantic search is not available in mockRoamEnvironment"
+        );
       },
     },
   };

--- a/src/testing/mockRoamEnvironment.ts
+++ b/src/testing/mockRoamEnvironment.ts
@@ -1480,18 +1480,9 @@ const mockRoamEnvironment = () => {
   };
   global.window.roamAlphaAPI.data = {
     ...global.window.roamAlphaAPI.data,
-    semanticSearchEnabled: () => false,
     fast: {
       q: (query, ..._params) => {
         return mockQuery({ graph, query });
-      },
-    },
-    async: {
-      ...global.window.roamAlphaAPI.data?.async,
-      semanticSearch: async () => {
-        throw new Error(
-          "Semantic search is not available in mockRoamEnvironment"
-        );
       },
     },
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 import {
   AddPullWatch,
   PullBlock,
+  SemanticSearch,
   SidebarAction,
   SidebarWindow,
   SidebarWindowInput,
@@ -102,6 +103,7 @@ declare global {
       };
       data: {
         addPullWatch: AddPullWatch;
+        semanticSearchEnabled: () => boolean;
         block: {
           create: WriteAction;
           update: WriteAction;
@@ -125,6 +127,7 @@ declare global {
             pattern: string,
             eids: string[][],
           ) => Promise<PullBlock[]>;
+          semanticSearch: SemanticSearch;
           fast: {
             q: (query: string, ...params: unknown[]) => Promise<unknown[][]>;
           };

--- a/src/types/native.ts
+++ b/src/types/native.ts
@@ -332,6 +332,22 @@ export type RoamError = {
   "status-code": number;
 };
 
+export type SemanticSearchArgs = {
+  "search-str": string;
+  k?: number;
+  "hide-code-blocks"?: boolean;
+};
+
+export type SemanticSearchHit = {
+  type: "chunk" | "block" | "page";
+  uid: string;
+  topUids: string[];
+};
+
+export type SemanticSearch = (
+  args: SemanticSearchArgs
+) => Promise<SemanticSearchHit[]>;
+
 export type TreeNode = {
   text: string;
   order: number;


### PR DESCRIPTION
## Summary

Adds TypeScript coverage for the new Roam semantic search API surface:

- exports `SemanticSearchArgs`, `SemanticSearchHit`, and `SemanticSearch`
- declares `window.roamAlphaAPI.data.semanticSearchEnabled()`
- declares `window.roamAlphaAPI.data.async.semanticSearch(...)`

No mock environment defaults are included.

## Impact

Extension authors can now call the new async semantic search API with typed arguments and hit records. Callers can use `semanticSearchEnabled()` before invoking the async API, matching Roam's availability guard contract.

## Validation

- `npm run build` passes
- `npm run lint` passes with one existing warning in `src/types/index.ts`
- `npm test` was previously blocked during test loading by existing missing modules: `../src/backend/getRoamJSUser` and `react-dom/client`