### PR TITLE
[codex] Type installed Roam Depot extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.88.3",
+  "version": "0.88.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.88.3",
+      "version": "0.88.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.88.3",
+  "version": "0.88.4",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,13 @@ export type Registry = {
   timeouts: { timeout: number }[];
 };
 
+export type InstalledExtension = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  version: string;
+};
+
 declare global {
   interface Window {
     // TODO remove
@@ -361,6 +368,9 @@ declare global {
         name: string;
         type: "hosted" | "offline";
         isEncrypted: boolean;
+      };
+      extension: {
+        getInstalledExtensions: () => Record<string, InstalledExtension>;
       };
       file: {
         upload: (args: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -369,7 +369,7 @@ declare global {
         type: "hosted" | "offline";
         isEncrypted: boolean;
       };
-      extension: {
+      depot: {
         getInstalledExtensions: () => Record<string, InstalledExtension>;
       };
       file: {


### PR DESCRIPTION
## Summary
- Add an `InstalledExtension` type for Roam Depot/dev-mode installed extensions.
- Type `window.roamAlphaAPI.extension.getInstalledExtensions()` in the shared global Roam API definition.

## Validation
- `npm run build`